### PR TITLE
Update the runtime version from 6.8 to 6.10, and more

### DIFF
--- a/fix-build-errors.patch
+++ b/fix-build-errors.patch
@@ -1,0 +1,22 @@
+From 371330ce0c47b3e465c3b72f7cdf21514f2fbb8f Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Fri, 15 May 2026 17:33:14 +0300
+Subject: [PATCH] Fix build errors
+
+Signed-off-by: Sabri Ünal <yakushabb@gmail.com>
+---
+ src/cli/vendor/qcommandlinecommandparser/qcommandlinecommandparser.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/cli/vendor/qcommandlinecommandparser/qcommandlinecommandparser.cpp b/src/cli/vendor/qcommandlinecommandparser/qcommandlinecommandparser.cpp
+index 0742cac..073a1de 100644
+--- a/src/cli/vendor/qcommandlinecommandparser/qcommandlinecommandparser.cpp
++++ b/src/cli/vendor/qcommandlinecommandparser/qcommandlinecommandparser.cpp
+@@ -1,3 +1,4 @@
++#include <QDebug>
+ #include "qcommandlinecommandparser.h"
+ #include <QString>
+ #include "vendor.h"
+--
+libgit2 1.7.2
+

--- a/org.bionus.Grabber.yml
+++ b/org.bionus.Grabber.yml
@@ -1,6 +1,6 @@
 app-id: org.bionus.Grabber
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: Grabber
 rename-icon: grabber
@@ -24,12 +24,17 @@ finish-args:
   - --device=dri
   - --filesystem=host
 
+cleanup:
+  - /include
+  - '*.a'
+
 modules:
   - name: grabber
     subdir: src
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     make-args:
       - gui
     sources:
@@ -40,4 +45,6 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$
+      - type: patch
+        path: fix-build-errors.patch
       - generated-sources.json


### PR DESCRIPTION
- Update the runtime version to 6.10
- Fix build errors
- Improve cleanup commands to reduce the Flatpak size

The installed size was reduced from 32.3 MB to 19.6 MB.